### PR TITLE
Remove unnecessary copy constructor

### DIFF
--- a/src/io/osu_buffer.cc
+++ b/src/io/osu_buffer.cc
@@ -131,4 +131,3 @@ void shiro::io::buffer::clear() {
 size_t shiro::io::buffer::get_size() {
     return this->written_size;
 }
-

--- a/src/io/osu_buffer.hh
+++ b/src/io/osu_buffer.hh
@@ -79,4 +79,3 @@ namespace shiro::io {
 }
 
 #endif //SHIRO_OSU_BUFFER_HH
-


### PR DESCRIPTION
non-const can always be promoted to const