### PR TITLE
Fix line ending issue on Windows

### DIFF
--- a/src/beatmaps/beatmap_helper.cc
+++ b/src/beatmaps/beatmap_helper.cc
@@ -71,7 +71,7 @@ FILE *shiro::beatmaps::helper::download(int32_t beatmap_id) {
     std::string filename = dir + utils::filesystem::preferred_separator + std::to_string(beatmap_id) + ".osu";
 
     if (fs::exists(filename))
-        return fopen(filename.c_str(), "r");
+        return std::fopen(filename.c_str(), "r");
 
     CURL *curl = curl_easy_init();
     CURLcode status_code;
@@ -96,10 +96,10 @@ FILE *shiro::beatmaps::helper::download(int32_t beatmap_id) {
         }
     }
 
-    FILE *map_file = fopen(filename.c_str(), "wb");
+    FILE *map_file = std::fopen(filename.c_str(), "wb");
 
-    fwrite(output.c_str(), sizeof(char), output.length(), map_file);
-    fclose(map_file);
+    std::fwrite(output.c_str(), sizeof(char), output.length(), map_file);
+    std::fclose(map_file);
 
-    return fopen(filename.c_str(), "r");
+    return std::fopen(filename.c_str(), "r");
 }

--- a/src/routes/impl/web/submit_score_route.cc
+++ b/src/routes/impl/web/submit_score_route.cc
@@ -329,7 +329,7 @@ void shiro::routes::web::submit_score::handle(const crow::request &request, crow
         d_free(&difficulty);
         p_free(&parser_state);
 
-        fclose(map_file);
+        std::fclose(map_file);
     } else {
         score.pp = 0;
     }


### PR DESCRIPTION
Fixes #66

This issue has led the `oppai-ng` PP calculator, to fail to parse the beatmap file, which had unexpected behaviour - extremely high PP gain which triggered anti-cheat, resulting in a restriction.

This also fixes issue with file still being open to read after beatmap parser was done.