### PR TITLE
Use "rb" to read from disk to prevent line ending catastrophes.

### DIFF
--- a/src/beatmaps/beatmap_helper.cc
+++ b/src/beatmaps/beatmap_helper.cc
@@ -71,7 +71,7 @@ FILE *shiro::beatmaps::helper::download(int32_t beatmap_id) {
     std::string filename = dir + utils::filesystem::preferred_separator + std::to_string(beatmap_id) + ".osu";
 
     if (fs::exists(filename))
-        return std::fopen(filename.c_str(), "r");
+        return std::fopen(filename.c_str(), "rb");
 
     CURL *curl = curl_easy_init();
     CURLcode status_code;


### PR DESCRIPTION
Similar to #66 but when reading from disk. Fixes pp calculation problems from the liboppai parsing catastrophe