### PR TITLE
Replace stream logging with printf style logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ if (Tcmalloc_FOUND)
 endif()
 
 # Enable logging with streams in Loguru
-add_definitions(-DLOGURU_WITH_STREAMS=1 -DLOGURU_REDEFINE_ASSERT=1)
+add_definitions(-DLOGURU_REDEFINE_ASSERT=1)
 
 # Resources
 file(GLOB_RECURSE RESOURCES ${CMAKE_CURRENT_SOURCE_DIR}/resources/*)

--- a/src/beatmaps/beatmap.cc
+++ b/src/beatmaps/beatmap.cc
@@ -187,7 +187,7 @@ bool shiro::beatmaps::beatmap::fetch_api() {
             if (part["approved_date"].is_null())
                 this->ranked_status = (int32_t) status::latest_pending;
         } catch (const boost::bad_lexical_cast &ex) {
-            LOG_S(ERROR) << "Unable to cast response of Bancho API to valid data types: " << ex.what() << ".";
+            LOG_F(ERROR, "Unable to cast response of Bancho API to valid data types: %s.", ex.what());
             logging::sentry::exception(ex);
 
             this->ranked_status = (int32_t) status::unknown;

--- a/src/bot/bot.cc
+++ b/src/bot/bot.cc
@@ -91,7 +91,7 @@ void shiro::bot::init() {
     std::shared_ptr<users::user> bot_user = std::make_shared<users::user>(1);
 
     if (!bot_user->init()) {
-        LOG_S(FATAL) << "Unable to initialize chat bot.";
+        ABORT_F("Unable to initialize chat bot.");
         return;
     }
 
@@ -120,7 +120,7 @@ void shiro::bot::init() {
         ctx.Repeat(30s);
     });
 
-    LOG_S(INFO) << "Bot has been successfully registered as " << config::bot::name << " and is now online.";
+    LOG_F(INFO, "Bot has been successfully registered as %s and is now online.", config::bot::name.c_str());
 }
 
 void shiro::bot::init_commands() {
@@ -136,7 +136,7 @@ void shiro::bot::init_commands() {
     commands_map.insert(std::make_pair("rtx", commands::rtx));
     commands_map.insert(std::make_pair("silence", commands::silence));
 
-    LOG_S(INFO) << "Bot commands have been successfully loaded. " << commands_map.size() << " commands available.";
+    LOG_F(INFO, "Bot commands have been successfully loaded. %lu commands available.", commands_map.size());
 }
 
 bool shiro::bot::handle(const std::string &command, std::deque<std::string> &args, std::shared_ptr<shiro::users::user> user, std::string channel) {

--- a/src/config/api_file.cc
+++ b/src/config/api_file.cc
@@ -29,13 +29,13 @@ std::string shiro::config::api::deploy_command = "";
 
 void shiro::config::api::parse() {
     if (config_file != nullptr)
-        LOG_S(INFO) << "Re-parsing api.toml file...";
+        LOG_F(INFO, "Re-parsing api.toml file...");
 
     try {
         config_file = cpptoml::parse_file("api.toml");
     } catch (const cpptoml::parse_exception &ex) {
         logging::sentry::exception(ex);
-        LOG_S(FATAL) << "Failed to parse api.toml file: " << ex.what() << ".";
+        ABORT_F("Failed to parse api.toml file: %s.", ex.what());
     }
 
     deploy_enabled = config_file->get_qualified_as<bool>("deploy.enabled").value_or(false);

--- a/src/config/bancho_file.cc
+++ b/src/config/bancho_file.cc
@@ -40,13 +40,13 @@ bool shiro::config::bancho::sentry_integration = true;
 
 void shiro::config::bancho::parse() {
     if (config_file != nullptr)
-        LOG_S(INFO) << "Re-parsing bancho.toml file...";
+        LOG_F(INFO, "Re-parsing bancho.toml file...");
 
     try {
         config_file = cpptoml::parse_file("bancho.toml");
     } catch (const cpptoml::parse_exception &ex) {
         logging::sentry::exception(ex);
-        LOG_S(FATAL) << "Failed to parse bancho.toml file: " << ex.what() << ".";
+        ABORT_F("Failed to parse bancho.toml file: %s.", ex.what());
     }
 
     host = config_file->get_qualified_as<std::string>("server.host").value_or("127.0.0.1");
@@ -63,7 +63,7 @@ void shiro::config::bancho::parse() {
 
     sentry_integration = config_file->get_qualified_as<bool>("integrations.sentry").value_or(true);
 
-    LOG_S(INFO) << "Successfully parsed bancho.toml.";
+    LOG_F(INFO, "Successfully parsed bancho.toml.");
 
     cli::cli_app.add_option("--bancho-host", host, "Host that Bancho should bind to");
     cli::cli_app.add_option("--bancho-port", port, "Port that Bancho should bind to");

--- a/src/config/bot_file.cc
+++ b/src/config/bot_file.cc
@@ -28,18 +28,18 @@ std::string shiro::config::bot::name = "Shiro";
 
 void shiro::config::bot::parse() {
     if (config_file != nullptr)
-        LOG_S(INFO) << "Re-parsing bot.toml file...";
+        LOG_F(INFO, "Re-parsing bot.toml file...");
 
     try {
         config_file = cpptoml::parse_file("bot.toml");
     } catch (const cpptoml::parse_exception &ex) {
         logging::sentry::exception(ex);
-        LOG_S(FATAL) << "Failed to parse bot.toml file: " << ex.what() << ".";
+        ABORT_F("Failed to parse bot.toml file: %s.", ex.what());
     }
 
     name = config_file->get_qualified_as<std::string>("bot.name").value_or("Shiro");
 
-    LOG_S(INFO) << "Successfully parsed bot.toml.";
+    LOG_F(INFO, "Successfully parsed bot.toml.");
 
     cli::cli_app.add_option("--bot-name", name, "Name of the chat bot");
 }

--- a/src/config/cli_args.cc
+++ b/src/config/cli_args.cc
@@ -31,7 +31,7 @@ void shiro::config::cli::parse(int argc, char **argv) {
     try {
         cli_app.parse(argc, argv);
     } catch (const CLI::ParseError &ex) {
-        LOG_S(FATAL) << "Unable to parse command line arguments: " << ex.what() << ".";
+        ABORT_F("Unable to parse command line arguments: %s.", ex.what());
     }
 }
 

--- a/src/config/db_file.cc
+++ b/src/config/db_file.cc
@@ -32,13 +32,13 @@ std::string shiro::config::database::password = "hunter2";
 
 void shiro::config::database::parse() {
     if (config_file != nullptr)
-        LOG_S(INFO) << "Re-parsing database.toml file...";
+        LOG_F(INFO, "Re-parsing database.toml file...");
 
     try {
         config_file = cpptoml::parse_file("database.toml");
     } catch (const cpptoml::parse_exception &ex) {
         logging::sentry::exception(ex);
-        LOG_S(FATAL) << "Failed to parse database.toml file: " << ex.what() << ".";
+        ABORT_F("Failed to parse database.toml file: %s.", ex.what());
     }
 
     address = config_file->get_qualified_as<std::string>("database.address").value_or("127.0.0.1");
@@ -47,7 +47,7 @@ void shiro::config::database::parse() {
     username = config_file->get_qualified_as<std::string>("database.username").value_or("root");
     password = config_file->get_qualified_as<std::string>("database.password").value_or("hunter2");
 
-    LOG_S(INFO) << "Successfully parsed database.toml.";
+    LOG_F(INFO, "Successfully parsed database.toml.");
 
     cli::cli_app.add_option("--db-address", address, "Address of MySQL server to connect to");
     cli::cli_app.add_option("--db-port", port, "Port of MySQL server to connect to");

--- a/src/config/score_submission_file.cc
+++ b/src/config/score_submission_file.cc
@@ -88,13 +88,13 @@ bool shiro::config::score_submission::key_coop_ranked = false;
 
 void shiro::config::score_submission::parse() {
     if (config_file != nullptr)
-        LOG_S(INFO) << "Re-parsing score_submission.toml file...";
+        LOG_F(INFO, "Re-parsing score_submission.toml file...");
 
     try {
         config_file = cpptoml::parse_file("score_submission.toml");
     } catch (const cpptoml::parse_exception &ex) {
         logging::sentry::exception(ex);
-        LOG_S(FATAL) << "Failed to parse score_submission.toml file: " << ex.what() << ".";
+        ABORT_F("Failed to parse score_submission.toml file: %s.", ex.what());
     }
 
     save_failed_scores = config_file->get_qualified_as<bool>("save_failed_scores").value_or(true);
@@ -156,7 +156,7 @@ void shiro::config::score_submission::parse() {
     key_9_ranked = config_file->get_qualified_as<bool>("ranked_keys.key_9").value_or(false);
     key_coop_ranked = config_file->get_qualified_as<bool>("ranked_keys.key_coop").value_or(false);
 
-    LOG_S(INFO) << "Successfully parsed score_submission.toml.";
+    LOG_F(INFO, "Successfully parsed score_submission.toml.");
 
     // Most of these values here are boolean
     // Passing booleans as CLI arguments is a limitation of the CLI library

--- a/src/database/database.cc
+++ b/src/database/database.cc
@@ -49,7 +49,7 @@ void shiro::database::connect() {
         this->config->debug = true;
     #endif
 
-    LOG_S(INFO) << "Successfully connected to MySQL database.";
+    LOG_F(INFO, "Successfully connected to MySQL database.");
 }
 
 void shiro::database::setup() {
@@ -128,7 +128,7 @@ void shiro::database::setup() {
             "permissions BIGINT UNSIGNED NOT NULL, color TINYINT UNSIGNED NOT NULL);"
     );
 
-    LOG_S(INFO) << "Successfully created and structured tables in database.";
+    LOG_F(INFO, "Successfully created and structured tables in database.");
 }
 
 bool shiro::database::is_connected(bool abort) {
@@ -143,7 +143,7 @@ bool shiro::database::is_connected(bool abort) {
         logging::sentry::exception(ex);
 
         if (abort)
-            LOG_S(FATAL) << "Unable to connect to database: " << ex.what();
+            ABORT_F("Unable to connect to database: %s.", ex.what());
 
         return false;
     }

--- a/src/geoloc/maxmind_resolver.cc
+++ b/src/geoloc/maxmind_resolver.cc
@@ -31,7 +31,7 @@ void shiro::geoloc::maxmind::init() {
     if (code == MMDB_SUCCESS)
         return;
 
-    LOG_F(FATAL, "Unable to open maxmind db database: %s", MMDB_strerror(code));
+    ABORT_F("Unable to open maxmind db database: %s", MMDB_strerror(code));
 }
 
 void shiro::geoloc::maxmind::destroy() {

--- a/src/handlers/login_handler.cc
+++ b/src/handlers/login_handler.cc
@@ -124,7 +124,7 @@ void shiro::handler::login::handle(const crow::request &request, crow::response 
     try {
         build = boost::lexical_cast<int32_t>(parseable_version);
     } catch (const boost::bad_lexical_cast &ex) {
-        LOG_S(WARNING) << "Unable to cast " << version << " to int32_t: " << ex.what();
+        LOG_F(WARNING, "Unable to cast %s to int32_t: %s", version.c_str(), ex.what());
         logging::sentry::exception(ex);
 
         if (config::score_submission::restrict_mismatching_client_version) {
@@ -134,7 +134,7 @@ void shiro::handler::login::handle(const crow::request &request, crow::response 
             return;
         }
     } catch (const std::out_of_range &ex) {
-        LOG_S(WARNING) << "Unable to convert client version " << version << " to valid build: " << ex.what();
+        LOG_F(WARNING, "Unable to convert client version %s to valid build: %s.", version.c_str(), ex.what());
         logging::sentry::exception(ex);
 
         if (config::score_submission::restrict_mismatching_client_version) {
@@ -162,7 +162,7 @@ void shiro::handler::login::handle(const crow::request &request, crow::response 
     try {
         time_zone = (int8_t) boost::lexical_cast<int32_t>(utc_offset);
     } catch (const boost::bad_lexical_cast &ex) {
-        LOG_S(WARNING) << "Unable to cast " << utc_offset << " to int32_t (int8_t): " << ex.what() << ".";
+        LOG_F(WARNING, "Unable to cast %s to int32_t (int8_t): %s.", utc_offset.c_str(), ex.what());
         logging::sentry::exception(ex);
     }
 

--- a/src/logger/logger.cc
+++ b/src/logger/logger.cc
@@ -51,5 +51,5 @@ void shiro::logging::init(int argc, char **argv) {
 
     loguru::init(argc, argv);
 
-    LOG_S(INFO) << "Logging was successfully initialized.";
+    LOG_F(INFO, "Logging was successfully initialized.");
 }

--- a/src/logger/route_logger.cc
+++ b/src/logger/route_logger.cc
@@ -22,16 +22,16 @@
 void shiro::logging::route_logger::log(std::string message, crow::LogLevel level) {
     switch (level) {
         case crow::LogLevel::Info:
-            LOG_S(INFO) << message;
+            LOG_F(INFO, "%s", message.c_str());
             break;
         case crow::LogLevel::Warning:
-            LOG_S(WARNING) << message;
+            LOG_F(WARNING, "%s", message.c_str());
             break;
         case crow::LogLevel::Error:
-            LOG_S(ERROR) << message;
+            LOG_F(ERROR, "%s", message.c_str());
             break;
         case crow::LogLevel::Critical:
-            LOG_S(FATAL) << message;
+            ABORT_F("%s", message.c_str());
             break;
         default:
             // Do nothing

--- a/src/native/linux/signal_handler_linux.cc
+++ b/src/native/linux/signal_handler_linux.cc
@@ -19,6 +19,7 @@
 #if defined(__linux__) || defined(__APPLE__) // This is a exception because the signal handlers are the same on *nix
 
 #include <csignal>
+#include <cstdlib>
 
 #include "../../thirdparty/loguru.hh"
 #include "../signal_handler.hh"
@@ -27,7 +28,7 @@ void handle_signal(int signal) {
     if (signal != SIGINT)
         return;
 
-    LOG_S(INFO) << "Shutting down...";
+    LOG_F(INFO, "Shutting down...");
     std::exit(EXIT_SUCCESS);
 }
 
@@ -39,7 +40,7 @@ void shiro::native::signal_handler::install() {
 
     sigaction(SIGINT, &sig_int_handler, nullptr);
 
-    LOG_S(INFO) << "Signal handler was successfully installed.";
+    LOG_F(INFO, "Signal handler was successfully installed.");
 }
 
 #endif

--- a/src/native/win/signal_handler_windows.cc
+++ b/src/native/win/signal_handler_windows.cc
@@ -27,7 +27,7 @@
 bool handle_signal(unsigned int signal) {
     switch (signal) {
         case CTRL_C_EVENT:
-            LOG_S(INFO) << "Shutting down...";
+            LOG_F(INFO, "Shutting down...");
             std::exit(EXIT_SUCCESS);
         case CTRL_CLOSE_EVENT:
             return true;
@@ -38,9 +38,9 @@ bool handle_signal(unsigned int signal) {
 
 void shiro::native::signal_handler::install() {
     if (!SetConsoleCtrlHandler((PHANDLER_ROUTINE) handle_signal, true))
-        LOG_S(FATAL) << "Unable to install signal handler.";
+        ABORT_F("Unable to install signal handler.");
 
-    LOG_S(INFO) << "Signal handler was successfully installed.";
+    LOG_F(INFO, "Signal handler was successfully installed.");
 }
 
 #endif

--- a/src/replays/replay.cc
+++ b/src/replays/replay.cc
@@ -65,7 +65,7 @@ void shiro::replays::replay::parse() {
             a.y = boost::lexical_cast<float>(pieces.at(2));
             a.z = boost::lexical_cast<int32_t>(pieces.at(3));
         } catch (const boost::bad_lexical_cast &ex) {
-            LOG_S(ERROR) << "Unable to cast action values into correct data types:" << ex.what();
+            LOG_F(ERROR, "Unable to cast action values into correct data types: %s", ex.what());
             logging::sentry::exception(ex);
             continue;
         }

--- a/src/replays/replay_manager.cc
+++ b/src/replays/replay_manager.cc
@@ -132,7 +132,7 @@ void shiro::replays::save_replay(const shiro::scores::score &s, const beatmaps::
         stream << compressed.str();
         stream.close();
 
-        LOG_S(WARNING) << "Uncompressed replay was >1mb, saved replay with zlib compression.";
+        LOG_F(WARNING, "Uncompressed replay was >1mb, saved replay with zlib compression.");
     }
 }
 

--- a/src/routes/impl/web/get_replay_route.cc
+++ b/src/routes/impl/web/get_replay_route.cc
@@ -58,7 +58,7 @@ void shiro::routes::web::get_replay::handle(const crow::request &request, crow::
     try {
         id = boost::lexical_cast<int32_t>(score_id);
     } catch (const boost::bad_lexical_cast &ex) {
-        LOG_S(WARNING) << "Unable to convert score id " << score_id << " to int32_t: " << ex.what();
+        LOG_F(WARNING, "Unable to convert score id %s to int32_t: %s", score_id, ex.what());
         logging::sentry::exception(ex);
 
         response.code = 500;

--- a/src/routes/impl/web/get_scores_route.cc
+++ b/src/routes/impl/web/get_scores_route.cc
@@ -69,7 +69,7 @@ void shiro::routes::web::get_scores::handle(const crow::request &request, crow::
         beatmap.beatmap_md5 = md5sum;
         scoreboard_type = boost::lexical_cast<int32_t>(type);
     } catch (const boost::bad_lexical_cast &ex) {
-        LOG_S(ERROR) << "Unable to convert sent values to beatmap metadata: " << ex.what() << ".";
+        LOG_F(ERROR, "Unable to convert sent values to beatmap metadata: %s.", ex.what());
         logging::sentry::exception(ex);
 
         response.code = 500;
@@ -99,7 +99,7 @@ void shiro::routes::web::get_scores::handle(const crow::request &request, crow::
             try {
                 mods_list = boost::lexical_cast<int32_t>(mods);
             } catch (const boost::bad_lexical_cast &ex) {
-                LOG_S(ERROR) << "Unable to convert sent values to mods: " << ex.what() << ".";
+                LOG_F(ERROR, "Unable to convert sent values to mods: %s.", ex.what());
                 logging::sentry::exception(ex);
 
                 response.code = 500;

--- a/src/routes/impl/web/submit_score_route.cc
+++ b/src/routes/impl/web/submit_score_route.cc
@@ -61,7 +61,7 @@ void shiro::routes::web::submit_score::handle(const crow::request &request, crow
         response.code = 400;
         response.end("error: invalid");
 
-        LOG_S(ERROR) << "Received score submission without content type.";
+        LOG_F(ERROR, "Received score submission without content type.");
         return;
     }
 
@@ -77,7 +77,7 @@ void shiro::routes::web::submit_score::handle(const crow::request &request, crow
         response.code = 403;
         response.end("error: pass");
 
-        LOG_S(WARNING) << "Received score submission without password.";
+        LOG_F(WARNING, "Received score submission without password.");
         return;
     }
 
@@ -85,7 +85,7 @@ void shiro::routes::web::submit_score::handle(const crow::request &request, crow
         response.code = 400;
         response.end("error: invalid");
 
-        LOG_S(WARNING) << "Received score without initialization vector.";
+        LOG_F(WARNING, "Received score without initialization vector.");
         return;
     }
 
@@ -93,7 +93,7 @@ void shiro::routes::web::submit_score::handle(const crow::request &request, crow
         response.code = 400;
         response.end("error: invalid");
 
-        LOG_S(WARNING) << "Received score without score data.";
+        LOG_F(WARNING, "Received score without score data.");
         return;
     }
 
@@ -110,7 +110,7 @@ void shiro::routes::web::submit_score::handle(const crow::request &request, crow
         response.code = 400;
         response.end("error: invalid");
 
-        LOG_S(WARNING) << "Received score without score metadata.";
+        LOG_F(WARNING, "Received score without score metadata.");
         return;
     }
 
@@ -123,7 +123,7 @@ void shiro::routes::web::submit_score::handle(const crow::request &request, crow
         response.code = 400;
         response.end("error: invalid");
 
-        LOG_S(WARNING) << "Received invalid score submission, score metadata doesn't have 16 or more parts.";
+        LOG_F(WARNING, "Received invalid score submission, score metadata doesn't have 16 or more parts.");
         return;
     }
 
@@ -135,7 +135,7 @@ void shiro::routes::web::submit_score::handle(const crow::request &request, crow
     if (user == nullptr) {
         response.code = 403;
 
-        LOG_S(WARNING) << "Received score submission from offline user.";
+        LOG_F(WARNING, "Received score submission from offline user.");
         return;
     }
 
@@ -194,7 +194,7 @@ void shiro::routes::web::submit_score::handle(const crow::request &request, crow
     try {
         game_version = boost::lexical_cast<int32_t>(score_metadata.at(17));
     } catch (const boost::bad_lexical_cast &ex) {
-        LOG_S(WARNING) << "Unable to convert " << score_metadata.at(17) << " to game version: " << ex.what();
+        LOG_F(WARNING, "Unable to convert %s to game version: %s.", score_metadata.at(17).c_str(), ex.what());
         logging::sentry::exception(ex);
 
         // Give the client a chance to resubmit so the player doesn't get restricted for a fail on our side.
@@ -257,7 +257,7 @@ void shiro::routes::web::submit_score::handle(const crow::request &request, crow
         if (config::score_submission::restrict_no_replay)
             users::punishments::restrict(user->user_id, 1, "No replay sent on score submission");
 
-        LOG_S(WARNING) << "Received score without replay data.";
+        LOG_F(WARNING, "Received score without replay data.");
         return;
     }
 

--- a/src/routes/routes.cc
+++ b/src/routes/routes.cc
@@ -50,7 +50,7 @@ void shiro::routes::init() {
         server.run();
     } catch (const boost::system::system_error &ex) {
         logging::sentry::exception(ex);
-        LOG_S(FATAL) << "Unable to start server: " << ex.what() << ".";
+        ABORT_F("Unable to start server: %s.", ex.what());
     }
 }
 

--- a/src/routes/routes.hh
+++ b/src/routes/routes.hh
@@ -33,35 +33,35 @@ namespace shiro::routes {
 
 }
 
-#define shiro_route(handler)                                                                                                \
-    [](const crow::request &request, crow::response &response) {                                                            \
-        logging::sentry::http_request_in(request);                                                                          \
-                                                                                                                            \
-        try {                                                                                                               \
-            handler(request, response);                                                                                     \
-        } catch (...) {                                                                                                     \
-            logging::sentry::exception(std::current_exception());                                                           \
-            LOG_S(ERROR) << "A exception occurred in " #handler ": " << boost::current_exception_diagnostic_information();  \
-                                                                                                                            \
-            response.code = 500;                                                                                            \
-            response.end();                                                                                                 \
-        }                                                                                                                   \
-    }                                                                                                                       \
+#define shiro_route(handler)                                                                                                        \
+    [](const crow::request &request, crow::response &response) {                                                                    \
+        logging::sentry::http_request_in(request);                                                                                  \
+                                                                                                                                    \
+        try {                                                                                                                       \
+            handler(request, response);                                                                                             \
+        } catch (...) {                                                                                                             \
+            logging::sentry::exception(std::current_exception());                                                                   \
+            LOG_F(ERROR, "A exception occurred in %s: %s", #handler, boost::current_exception_diagnostic_information().c_str());    \
+                                                                                                                                    \
+            response.code = 500;                                                                                                    \
+            response.end();                                                                                                         \
+        }                                                                                                                           \
+    }                                                                                                                               \
 
 // Currently only allows for one parameter but we can expand upon this when needed
-#define shiro_route_parameterized(handler, type, param)                                                                     \
-    [](const crow::request &request, crow::response &response, type param) {                                                \
-        logging::sentry::http_request_in(request);                                                                          \
-                                                                                                                            \
-        try {                                                                                                               \
-            handler(request, response, param);                                                                              \
-        } catch (...) {                                                                                                     \
-            logging::sentry::exception(std::current_exception());                                                           \
-            LOG_S(ERROR) << "A exception occurred in " #handler ": " << boost::current_exception_diagnostic_information();  \
-                                                                                                                            \
-            response.code = 500;                                                                                            \
-            response.end();                                                                                                 \
-        }                                                                                                                   \
-    }                                                                                                                       \
+#define shiro_route_parameterized(handler, type, param)                                                                             \
+    [](const crow::request &request, crow::response &response, type param) {                                                        \
+        logging::sentry::http_request_in(request);                                                                                  \
+                                                                                                                                    \
+        try {                                                                                                                       \
+            handler(request, response, param);                                                                                      \
+        } catch (...) {                                                                                                             \
+            logging::sentry::exception(std::current_exception());                                                                   \
+            LOG_F(ERROR, "A exception occurred in %s: %s", #handler, boost::current_exception_diagnostic_information().c_str());    \
+                                                                                                                                    \
+            response.code = 500;                                                                                                    \
+            response.end();                                                                                                         \
+        }                                                                                                                           \
+    }                                                                                                                               \
 
 #endif //SHIRO_ROUTES_HH

--- a/src/shiro.cc
+++ b/src/shiro.cc
@@ -123,5 +123,5 @@ void shiro::destroy() {
 
     scheduler.CancelAll();
 
-    LOG_S(INFO) << "Thank you and goodbye.";
+    LOG_F(INFO, "Thank you and goodbye.");
 }


### PR DESCRIPTION
This pull request replaces all `LOG_S` with `LOG_F`. Thus every class that includes `loguru.hh` (from thirdparty) no longer includes `iostream`, which improves compile time massively.

I've also gone ahead and replaced all `FATAL` logs with `ABORT`. This is the suggested way by  loguru itself and not doing this is considered an anti-pattern.

* Compile time **before**: 3 minutes 21 seconds
* Compile time **after**: 2 minutes 54 seconds

Time saved: **27 seconds**
This is a compile time improvement of **over 13%**.


