### PR TITLE
Fix beatmaps with full name > 128 not being added to database

### DIFF
--- a/src/beatmaps/beatmap.cc
+++ b/src/beatmaps/beatmap.cc
@@ -152,8 +152,8 @@ bool shiro::beatmaps::beatmap::fetch_api() {
             std::string version = part["version"];
 
             char buffer[128];
-            std::snprintf(buffer, 128, "%s - %s [%s]", artist.c_str(), title.c_str(), version.c_str());
-            this->song_name = std::string(buffer);
+            std::snprintf(buffer, sizeof(buffer), "%s - %s [%s]", artist.c_str(), title.c_str(), version.c_str());
+            this->song_name = buffer;
 
             this->beatmap_md5 = part["file_md5"];
             this->beatmapset_id = boost::lexical_cast<int32_t>(std::string(part["beatmapset_id"]));


### PR DESCRIPTION
The database varchar for `song_name` is explicitly limited to 128 characters. This would cause issues with beatmaps with long names such as [this one](https://osu.ppy.sh/beatmapsets/925343#osu/1947968). They would end up never being added to database, preventing score listing and score submission on this beatmap.