### PR TITLE
Fixed Spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It outperforms Ripple, Gigamons and even Bancho itself.
 In terms of implementation accuracy, Shiro's implementation is
 more accurate than both of Ripple and Gigamons.
 
-Unlike other implementations, Shiro does not seperate
+Unlike other implementations, Shiro does not separate
 Bancho and the Score Submission server.
 
 ## Features


### PR DESCRIPTION
Fixed Spelling of Separate in README

It's a bit of a stupid pull request but I did it anyways as I found it whilst snooping